### PR TITLE
add default WORKDIR for base image and bring in helpful crossplane Makefile fallthrough

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,22 +3,27 @@ PROJECT_NAME := pkg-unpack
 PROJECT_REPO := github.com/crossplane/$(PROJECT_NAME)
 
 PLATFORMS ?= linux_amd64 linux_arm64
-include build/makelib/common.mk
+-include build/makelib/common.mk
 
 S3_BUCKET ?= crossplane.releases/pkg-unpack
-include build/makelib/output.mk
+-include build/makelib/output.mk
 
 # Setup Go
 GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/pkg-unpack
 GO_SUBDIRS += cmd
 GO_LDFLAGS += -X $(GO_PROJECT)/pkg/version.Version=$(VERSION)
 GO111MODULE = on
-include build/makelib/golang.mk
+-include build/makelib/golang.mk
 
 # Docker images
 DOCKER_REGISTRY = crossplane
 IMAGES = pkg-unpack
-include build/makelib/image.mk
+-include build/makelib/image.mk
+
+# Update the submodules, such as the common build scripts.
+submodules:
+	@git submodule sync
+	@git submodule update --init --recursive
 
 # We want submodules to be set up the first time `make` is run.
 # We manage the build/ folder and its Makefiles as a submodule.
@@ -28,3 +33,25 @@ include build/makelib/image.mk
 fallthrough: submodules
 	@echo Initial setup complete. Running make again . . .
 	@make
+
+
+.PHONY: submodules fallthrough
+
+# ====================================================================================
+# Special Targets
+
+define CROSSPLANE_MAKE_HELP
+Crossplane Targets:
+    submodules         Update the submodules, such as the common build scripts.
+
+endef
+# The reason CROSSPLANE_MAKE_HELP is used instead of CROSSPLANE_HELP is because the crossplane
+# binary will try to use CROSSPLANE_HELP if it is set, and this is for something different.
+export CROSSPLANE_MAKE_HELP
+
+crossplane.help:
+	@echo "$$CROSSPLANE_MAKE_HELP"
+
+help-special: crossplane.help
+
+.PHONY: crossplane.help help-special

--- a/cluster/images/pkg-unpack/Dockerfile
+++ b/cluster/images/pkg-unpack/Dockerfile
@@ -5,5 +5,6 @@ ARG TINI_VERSION
 
 ADD pkg-unpack /usr/local/bin/pkg-unpack
 
+WORKDIR /crossplane-package/
 USER 1001
 ENTRYPOINT ["pkg-unpack"]


### PR DESCRIPTION
Allowing the package builder to assume a default WORKDIR has been set in the base image allows control of the package location to be given to the base image builder, so that dynamic base images can control the location of packaged resources.

Note that I also copied some bits over from the main crossplane Makefile to handle git submodule initialization and enable `make help`. I can split those changes out if that isn't considered helpful.

Signed-off-by: Kasey Kirkham <kasey@upbound.io>