### PR TITLE
meta: Add OWNERS file and PR/Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug Report
+about: Help us diagnose and fix bugs in Crossplane
+labels: bug
+---
+<!--
+Thank you for helping to improve Crossplane!
+
+Please be sure to search for open issues before raising a new one. We use issues
+for bug reports and feature requests. Please find us at https://slack.crossplane.io
+for questions, support, and discussion.
+-->
+
+### What happened?
+<!--
+Please let us know what behaviour you expected and how Crossplane diverged from
+that behaviour.
+-->
+
+
+### How can we reproduce it?
+<!--
+Help us to reproduce your bug as succinctly and precisely as possible. Artifacts
+such as example manifests or a script that triggers the issue are highly
+appreciated!
+-->
+
+### What environment did it happen in?
+Crossplane version: 
+
+<!--
+Include at least the version or commit of Crossplane you were running. Consider
+also including your:
+
+* Cloud provider or hardware configuration
+* Kubernetes version (use `kubectl version`)
+* Kubernetes distribution (e.g. Tectonic, GKE, OpenShift)
+* OS (e.g. from /etc/os-release)
+* Kernel (e.g. `uname -a`)
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature Request
+about: Help us make Crossplane more useful
+labels: enhancement
+---
+<!--
+Thank you for helping to improve Crossplane!
+
+Please be sure to search for open issues before raising a new one. We use issues
+for bug reports and feature requests. Please find us at https://slack.crossplane.io
+for questions, support, and discussion.
+-->
+
+### What problem are you facing?
+<!--
+Please tell us a little about your use case - it's okay if it's hypothetical!
+Leading with this context helps frame the feature request so we can ensure we
+implement it sensibly.
+--->
+
+### How could Crossplane help solve your problem?
+<!--
+Let us know how you think Crossplane could help with your use case. 
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+<!--
+Thank you for helping to improve Crossplane!
+
+Please read through https://git.io/fj2m9 if this is your first time opening a
+Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
+you need any help contributing.
+-->
+
+### Description of your changes
+
+<!--
+Briefly describe what this pull request does. Be sure to direct your reviewers'
+attention to anything that needs special consideration.
+
+We love pull requests that resolve an open Crossplane issue. If yours does, you
+can uncomment the below line to indicate which issue your PR fixes, for example
+"Fixes #500":
+
+-->
+Fixes #
+
+I have:
+
+- [ ] Read and followed Crossplane's [contribution process].
+- [ ] Run `make reviewable test` to ensure this PR is ready for review.
+
+### How has this code been tested
+
+<!--
+Before reviewers can be confident in the correctness of this pull request, it
+needs to tested and shown to be correct. Briefly describe the testing that has
+already been done or which is planned for this change.
+-->
+
+[contribution process]: https://git.io/fj2m9

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,0 +1,16 @@
+# OWNERS
+
+This page lists all maintainers for **this** repository. Each repository in the [Crossplane
+organization](https://github.com/crossplane/) will list their repository maintainers in their own
+`OWNERS.md` file.
+
+Please see the Crossplane
+[GOVERNANCE.md](https://github.com/crossplane/crossplane/blob/master/GOVERNANCE.md) for governance
+guidelines and responsibilities for the steering committee and maintainers.
+
+## Maintainers
+
+* Nic Cope <negz@upbound.io> ([negz](https://github.com/negz))
+* Daniel Mangum <dan@upbound.io> ([hasheddan](https://github.com/hasheddan))
+* Muvaffak Onus <monus@upbound.io> ([muvaf](https://github.com/muvaf))
+* Kasey Kirkham <kasey@upbound.io> ([kasey](https://github.com/kasey))


### PR DESCRIPTION
This PR adds some metadata files to this repo including the OWNERS.md and templates for PRs and issues.

I have also updated the access to this repo to match the proposed OWNERS, and added branch protection rules.